### PR TITLE
Fix markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Ironhide
 ========
 
 Espresso Android Testing Framework.
-* [Setting up Ironhide] (https://github.com/mindbody/Ironhide/wiki/Setting-Up-Ironhide)
+* [Setting up Ironhide](https://github.com/mindbody/Ironhide/wiki/Setting-Up-Ironhide)
 * [Introduction to Ironhide](https://github.com/mindbody/Ironhide/wiki/Introduction-to-Ironhide)
 * [Why Ironhide](https://github.com/mindbody/Ironhide/wiki/Why-Ironhide%3F)
 * [Tips and Tricks](https://github.com/mindbody/Ironhide/wiki/Tips-and-Tricks)


### PR DESCRIPTION
Noticed a very small formatting issue while checking out this repository. 

This PR fixes the markdown formatting of the `Setting up Ironhide` link in the README so that it is displayed as a link properly. 